### PR TITLE
add git log --graph command to readme

### DIFF
--- a/Git.md
+++ b/Git.md
@@ -159,6 +159,12 @@ git log
 git log --oneline
 ```
 
+- Exibe histórico de commits com estrutura gráfica de branches e merges.
+
+```bash
+git log --graph
+```
+
 - Exibe o log de uma branch específica
 
 ```bash


### PR DESCRIPTION
Este PR adiciona uma descrição do comando git log --graph ao arquivo README. Esse comando ajuda a visualizar o histórico de commits com uma representação gráfica das branches e merges, facilitando a compreensão do fluxo de desenvolvimento do projeto. A atualização visa melhorar a documentação para usuários e colaboradores.